### PR TITLE
Add ability to document .jsx and .tsx (React JSX) files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+# for Jetbrains IDEA ides
+.idea

--- a/cmds/index.js
+++ b/cmds/index.js
@@ -15,7 +15,7 @@ const { checkExtension, getFilename } = require('../helpers/utils');
 
 const fileTree = [];
 
-const extensions = ['.ts', '.js', '.vue'];
+const extensions = ['.ts', '.js', '.jsx', '.vue'];
 
 /**
  * Default command that generate md files
@@ -142,7 +142,7 @@ async function generate(argv, ctx) {
               mdFileData = await vuedoc.md({
                 filename: `${folder}/${file}`
               });
-            } else if (/\.(js|ts)$/.test(file) && fileData) {
+            } else if (/\.(js|ts|jsx)$/.test(file) && fileData) {
               const configPath = argv.jsDocConfigPath;
 
               try {

--- a/cmds/index.js
+++ b/cmds/index.js
@@ -15,7 +15,7 @@ const { checkExtension, getFilename } = require('../helpers/utils');
 
 const fileTree = [];
 
-const extensions = ['.ts', '.js', '.jsx', '.vue'];
+const extensions = ['.ts', '.js', '.tsx', '.jsx', '.vue'];
 
 /**
  * Default command that generate md files
@@ -142,7 +142,7 @@ async function generate(argv, ctx) {
               mdFileData = await vuedoc.md({
                 filename: `${folder}/${file}`
               });
-            } else if (/\.(js|ts|jsx)$/.test(file) && fileData) {
+            } else if (/\.(js|ts|jsx|tsx)$/.test(file) && fileData) {
               const configPath = argv.jsDocConfigPath;
 
               try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-jsdoc",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Generate jsdoc markdown files for vuepress",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
two small changes to add the .jsx file type, after which vuepress-jsdoc appears to operate with jsdoc inside them.

It's a bit funny yet with ES6 arrow functions, and the position for class jsdoc seems to need to be above the class rather than within it, but very happy to have this tool, and imagine those issues will sort out independent of this PR.  Thanks.