### PR TITLE
feat(cli): allow to specify multiple rm patterns

### DIFF
--- a/cmds/index.js
+++ b/cmds/index.js
@@ -28,10 +28,10 @@ async function generate(argv) {
   const docsFolder = `${argv.dist}/${codeFolder}`;
   const title = argv.title;
   const readme = argv.readme;
-  const rmPattern = argv.rmPattern || '';
+  const rmPattern = argv.rmPattern || [];
 
   // remove docs folder, except README.md
-  const deletedPaths = await del([docsFolder + '/**/*', `!${docsFolder}/README.md`, rmPattern]);
+  const deletedPaths = await del([docsFolder + '/**/*', `!${docsFolder}/README.md`, ...rmPattern]);
 
   /**
    * Read all files in directory

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function main() {
             alias: 'rm',
             default: '',
             desc: 'Pattern when removing files. You can ex- and include files. (glob pattern)',
-            type: 'string'
+            type: 'array'
           },
           jsDocConfigPath: {
             alias: 'c',


### PR DESCRIPTION
With this PR multiple rm patterns can be specified as command line arguments:

```
vuepress-jsdoc --rm '!./documentation/general' --rm './documentation/README.md'
```