### PR TITLE
feat(title): do not add duplicate header for vuedoc.md parsed files

### DIFF
--- a/cmds/index.js
+++ b/cmds/index.js
@@ -129,7 +129,7 @@ async function generate(argv) {
 
               let fileContent = '---\n';
 
-              fileContent += !attributes || !attributes.title ? `title: ${file}` : '';
+              fileContent += !attributes || !attributes.title ? `title: ${fileName}` : '';
 
               if (frontmatter) {
                 fileContent += !attributes || !attributes.title ? '\n' : '';
@@ -137,7 +137,9 @@ async function generate(argv) {
               }
 
               fileContent += '\n---\n';
-              fileContent += `\n# ${attributes && attributes.title ? attributes.title : file}\n\n`;
+              if ((attributes && attributes.title) || !/\.vue$/.test(file)) {
+                fileContent += `\n# ${attributes && attributes.title ? attributes.title : fileName}\n\n`;
+              }
               fileContent += mdFileData;
 
               await fs.writeFile(`${folderPath}/${fileName}.md`, fileContent);


### PR DESCRIPTION
This will exclude the newly added title from .vue file documentation, since otherwise there would be a duplicate title. It also switches from the full filename with extension to just the name, which seems a bit more suitable for documentation purposes. In case the `@vuepress` annotation is used the title will still be added.