### PR TITLE
feat: add option include

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Use these options after `vuepress-jsdoc`.
 | --help            | -h    |                 | Show help                                                                                                                                       |
 | --version         | -v    |                 | Show current version                                                                                                                            |
 | --readme          | -r    |                 | Path to custom readme file                                                                                                                      |
-| --exclude         | -e    |                 | Pattern to exclude files/folders (Comma seperated) - \*.test.js,exclude.js [more information](https://github.com/micromatch/micromatch#ismatch) |
+| --include         | -e    |                 | Pattern to include files (Comma seperated) - \*.test.js,include.js [more information](https://github.com/micromatch/micromatch#ismatch) |
+| --exclude         | -e    |                 | Pattern to exclude files (Comma seperated) - \*.test.js,exclude.js [more information](https://github.com/micromatch/micromatch#ismatch) |
 | --rmPattern       | -rm   |                 | Pattern when removing files. You can ex- and include files. (glob pattern)                                                                      |
 | --partials        | -p    |                 | jsdoc2markdown partial templates (overwrites default ones)                                                                                      |
 | --jsDocConfigPath | -c    |                 | Path to [JsDoc Config](http://usejsdoc.org/about-configuring-jsdoc.html) (experimental)                                                         |

--- a/src/__tests__/list-folder.test.ts
+++ b/src/__tests__/list-folder.test.ts
@@ -28,8 +28,7 @@ describe('test file-structure', () => {
         { ext: '.js', folder: 'src/', isDir: false, name: 'file1', path: 'src/file1.js' },
         { ext: '.ts', folder: 'src/', isDir: false, name: 'file2', path: 'src/file2.ts' },
         { ext: '.vue', folder: 'src/lib/', isDir: false, name: 'file3', path: 'src/lib/file3.vue' },
-        { ext: '.js', folder: 'src/lib/', isDir: false, name: '__index__', path: 'src/lib/index.js' },
-        { isDir: true, name: 'lib', path: 'src/lib' }
+        { ext: '.js', folder: 'src/lib/', isDir: false, name: '__index__', path: 'src/lib/index.js' }
       ]);
 
       expect(tree).toEqual([
@@ -166,6 +165,91 @@ describe('test file-structure', () => {
 
       // @ts-ignore
       expect(excluded).toEqual([{ ext: '.js', folder: 'src/', isDir: false, name: 'file1', path: 'src/file1.js' }]);
+    });
+  });
+
+  describe('include', () => {
+    beforeEach(() => {
+      vol.reset();
+    });
+
+    test('should include all with empty string', async () => {
+      vol.fromJSON(
+        {
+          'file1.js': '',
+          'file2.ts': ''
+        },
+        './src'
+      );
+
+      const { paths } = await listFolder('./src', [], ['']);
+
+      // @ts-ignore
+      expect(paths).toEqual([
+        { ext: '.js', folder: 'src/', isDir: false, name: 'file1', path: 'src/file1.js' },
+        { ext: '.ts', folder: 'src/', isDir: false, name: 'file2', path: 'src/file2.ts' }
+      ]);
+    });
+
+    test('should not include with not matching string', async () => {
+      vol.fromJSON(
+        {
+          'file1.js': '',
+          'file2.ts': ''
+        },
+        './src'
+      );
+
+      const { paths } = await listFolder('./src', [], ['file3']);
+
+      // @ts-ignore
+      expect(paths).toEqual([]);
+    });
+
+    test('should include file', async () => {
+      vol.fromJSON(
+        {
+          'file1.js': '',
+          'file2.ts': ''
+        },
+        './src'
+      );
+
+      const { paths, excluded } = await listFolder('./src', [], ['file1.js']);
+
+      // @ts-ignore
+      expect(paths).toEqual([{ ext: '.js', folder: 'src/', isDir: false, name: 'file1', path: 'src/file1.js' }]);
+
+      // @ts-ignore
+      expect(excluded).toEqual([{ ext: '.ts', folder: 'src/', isDir: false, name: 'file2', path: 'src/file2.ts' }]);
+    });
+  });
+
+  describe('include and exclude', () => {
+    beforeEach(() => {
+      vol.reset();
+    });
+
+    test('should include file2.ts', async () => {
+      vol.fromJSON(
+        {
+          'file1.js': '',
+          'file2.ts': '',
+          'file3.ts': ''
+        },
+        './src'
+      );
+
+      const { paths, excluded } = await listFolder('./src', ['file3.ts'], ['*.ts']);
+
+      // @ts-ignore
+      expect(paths).toEqual([{ ext: '.ts', folder: 'src/', isDir: false, name: 'file2', path: 'src/file2.ts' }]);
+
+      // @ts-ignore
+      expect(excluded).toEqual([
+        { ext: '.js', folder: 'src/', isDir: false, name: 'file1', path: 'src/file1.js' },
+        { ext: '.ts', folder: 'src/', isDir: false, name: 'file3', path: 'src/file3.ts' }
+      ]);
     });
   });
 });

--- a/src/cmds.ts
+++ b/src/cmds.ts
@@ -24,7 +24,8 @@ export default (version: string) => {
     .option('-f, --folder <string>', 'Folder inside destination folder. Gets overwritten everytime', 'code')
     .option('-t, --title <string>', 'Title of your documentation', 'API')
     .option('-r, --readme <string>', 'Path to your custom readme')
-    .option('-e, --exclude <string>', 'Pattern to exclude files/folders (Comma seperated) - *.test.js,exclude.js')
+    .option('-i, --include <string>', 'Pattern to include files (Comma seperated) - *.test.js,include.js', '**/*')
+    .option('-e, --exclude <string>', 'Pattern to exclude files (Comma seperated) - *.test.js,exclude.js')
     .option('-w, --watch', 'This flag watches your source files')
     .option(
       '-rm, --rmPattern [files...]',

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,9 +93,12 @@ const createReadmeFile = async (argv: CLIArguments, deletedPaths?: string[]) => 
  * @returns {object} all arguments
  */
 const parseArguments = (argv: CLIArguments) => {
+  const srcFolder = argv.source;
+
   return {
     exclude: (argv.exclude || '').split(',').filter(Boolean),
-    srcFolder: argv.source.replace('./', ''),
+    include: (argv.include || '**/*').split(',').filter(Boolean),
+    srcFolder,
     codeFolder: argv.folder,
     docsFolder: `${argv.dist}/${argv.folder}`,
     title: argv.title,
@@ -110,14 +113,14 @@ const parseArguments = (argv: CLIArguments) => {
  * @param {object} argv passed arguments
  */
 export const generate = async (argv: CLIArguments) => {
-  const { exclude, srcFolder, codeFolder, docsFolder, title, rmPattern } = parseArguments(argv);
+  const { exclude, include, srcFolder, codeFolder, docsFolder, title, rmPattern } = parseArguments(argv);
 
   const startTime = +new Date();
 
   // remove docs folder, except README.md
   const deletedPaths = await del([`${docsFolder}/**/*`, ...rmPattern]);
 
-  const lsFolder = await listFolder(srcFolder, exclude);
+  const lsFolder = await listFolder(srcFolder, exclude, include);
 
   await mkdirp(docsFolder);
 
@@ -198,7 +201,7 @@ export const generate = async (argv: CLIArguments) => {
  * @param {CLIArguments} argv
  */
 const watchFiles = (argv: CLIArguments) => {
-  const { exclude, srcFolder, codeFolder, docsFolder, title } = parseArguments(argv);
+  const { exclude, include, srcFolder, codeFolder, docsFolder, title } = parseArguments(argv);
 
   if (argv.watch) {
     console.log('\n---\n\n👀 watching files...');
@@ -208,7 +211,7 @@ const watchFiles = (argv: CLIArguments) => {
     });
 
     watcher.on('change', async path => {
-      const lsFolder = await listFolder(srcFolder, exclude);
+      const lsFolder = await listFolder(srcFolder, exclude, include);
       const file = lsFolder.paths.find(p => p.path === path);
 
       readline.clearLine(process.stdout, 0);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,6 +8,7 @@ export interface DirectoryFile {
 
 export interface CLIArguments {
   exclude: string;
+  include: string;
   partials: string[];
   rmPattern: string[];
   folder: string;

--- a/src/lib/list-folder.ts
+++ b/src/lib/list-folder.ts
@@ -14,16 +14,30 @@ import { DirectoryFile, FileTree } from '../interfaces';
  * Recursively traverse folders and return exluded files, a file list and a file tree.
  * @param {string} srcPath path to source dir
  * @param {array} exclude exluded file patter list
+ * @param {array} include included file patter list
  * @param {string} mainPath path to hold source dir
  * @param {object} tree tree array
  * @returns {object} paths array, tree, excluded array
  */
-export const listFolder = async (srcPath: string, exclude: string[], mainPath?: string, tree: FileTree[] = []) => {
+export const listFolder = async (
+  srcPath: string,
+  exclude: string[],
+  include: string[] = ['**/*'],
+  mainPath?: string,
+  tree: FileTree[] = []
+) => {
   if (!Boolean(exclude) || !Array.isArray(exclude)) {
     exclude = [];
   }
 
   exclude = exclude.filter(Boolean);
+
+  if (!Boolean(include) || !Array.isArray(include)) {
+    include = ['**/*'];
+  }
+
+  include = include.filter(Boolean);
+  include = include.length === 0 ? ['**/*'] : include;
 
   const paths: DirectoryFile[] = [];
   const excluded: DirectoryFile[] = [];
@@ -57,27 +71,42 @@ export const listFolder = async (srcPath: string, exclude: string[], mainPath?: 
 
     const baseSrc = mainPath || srcPath;
 
-    if (!mm.isMatch(path.join(srcPath.replace(baseSrc, ''), dirent.name), exclude)) {
-      let treeEntry: FileTree = {
-        name
-      };
+    let treeEntry: FileTree = {
+      name
+    };
 
-      if (isDir) {
-        treeEntry.children = [];
-        paths.push(...(await listFolder(filePath, exclude, baseSrc, treeEntry.children)).paths);
-      } else {
+    if (isDir) {
+      treeEntry.children = [];
+      const { paths: dirPaths, excluded: dirExcluded } = await listFolder(
+        filePath,
+        exclude,
+        include,
+        baseSrc,
+        treeEntry.children
+      );
+
+      excluded.push(...dirExcluded);
+      paths.push(...dirPaths);
+
+      if (dirPaths.length > 0) {
+        tree.push(treeEntry);
+      }
+    } else {
+      const testPath = path.join(path.relative(baseSrc, srcPath), dirent.name);
+
+      if (!mm.isMatch(testPath, exclude) && mm.isMatch(testPath, include)) {
         treeEntry = {
           ...treeEntry,
           path: `/${name}`,
           fullPath: path.join(srcPath, name),
           ext
         };
-      }
 
-      tree.push(treeEntry);
-      paths.push(file);
-    } else {
-      excluded.push(file);
+        tree.push(treeEntry);
+        paths.push(file);
+      } else {
+        excluded.push(file);
+      }
     }
   }
 


### PR DESCRIPTION
Hi

I think it would be nice to have an include option.

include and exclude should work identical to the options in [`tsconfig`](https://www.typescriptlang.org/tsconfig#include)

> exclude only changes which files are included as a result of the include setting

Changes:
- add new command-line option: -i --include <string>
- remove `replace('./', '')` from `argv.source`, because paths like `../sibling/src` resolve to `.sibling/src` 
- modify function `listFolder`

BREAKING CHANGE: it is only possible to exclude files (not folders)