### PR TITLE
fix: from vue-docgen-cli v4.64.0 extractConfig method is async and we…

### DIFF
--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -108,9 +108,10 @@ export const parseVueFile = async (
   const relativePathDest = join(destFolder, file.folder.replace(srcFolder, ''));
   const folderInDest = join(root, relativePathDest);
   const folderInSrc = join(root, file.folder);
+  const vueDocGenCliConf = await extractConfig(join(root, file.folder));
 
   const config = {
-    ...extractConfig(join(root, file.folder)),
+    ...vueDocGenCliConf,
     components: file.name + file.ext
   };
 


### PR DESCRIPTION
I started with a configuration problem after updating some dependencies, getting the below error

<img width="1728" alt="Screenshot 2023-06-01 at 16 20 16" src="https://github.com/ph1p/vuepress-jsdoc/assets/10166935/15e4e71c-0e3a-42b9-9fde-03095906269b">

After debugging it I detected that the `extractConfig` method returns only an object with the `components` property on it

<img width="1611" alt="Screenshot 2023-06-01 at 16 23 45" src="https://github.com/ph1p/vuepress-jsdoc/assets/10166935/aabfe510-6e5f-4f64-b24c-87058bfb5380">

and on `case 1` when it tray to use `config.componentsRoot` that property is `undefined` and makes the `path` function throws the error shown in the first print.

I checked the `extractConfig` method on `vue-docgen-cli`. I discovered that this method was converted to an `async` function which causes this new behaviour because the configuration from `vue-docgen-cli` is created successfully as you can see in the below screenshot.

<img width="1577" alt="Screenshot 2023-06-01 at 16 26 30" src="https://github.com/ph1p/vuepress-jsdoc/assets/10166935/ab47d482-e331-496b-a6b4-c90b7424793b">

To resume the function does not wait and the `config` object is set only with the `components` property because from `vue-docgen-cli v4.64.0` `extractConfig` method is `async` and we need to wait until it resolves the config.

As an extra check, we can confirm this change on the following [commit](https://github.com/vue-styleguidist/vue-styleguidist/commit/0cf928e9332f99d1168777f38e38bcc8637af0da).

and we also can confirm that on NPM in the new code tab

<img width="795" alt="Screenshot 2023-06-01 at 16 17 11" src="https://github.com/ph1p/vuepress-jsdoc/assets/10166935/8b2f219b-d8d2-45f2-abf2-bbb0375a89cc">

In previous versions, this method was not async

<img width="786" alt="Screenshot 2023-06-01 at 16 18 20" src="https://github.com/ph1p/vuepress-jsdoc/assets/10166935/a6619b65-5bb5-4fe9-b810-71a7f32f4a93">
