### PR TITLE
Replace exclude.js with include.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Use these options after `vuepress-jsdoc`.
 | --version         | -v    |                 | Show current version                                                                                                                            |
 | --readme          | -r    |                 | Path to custom readme file                                                                                                                      |
 | --exclude         | -e    |                 | Pattern to exclude files/folders (Comma seperated) - \*.test.js,exclude.js [more information](https://github.com/micromatch/micromatch#ismatch) |
-| --include         | -e    |                 | Pattern to include files/folders (Comma seperated) - \*.test.js,exclude.js [more information](https://github.com/micromatch/micromatch#ismatch) |
+| --include         | -e    |                 | Pattern to include files/folders (Comma seperated) - \*.test.js,include.js [more information](https://github.com/micromatch/micromatch#ismatch) |
 | --rmPattern       | -rm   |                 | Pattern when removing files. You can ex- and include files. (glob pattern)                                                                      |
 | --partials        | -p    |                 | jsdoc2markdown partial templates (overwrites default ones)                                                                                      |
 | --jsDocConfigPath | -c    |                 | Path to [JsDoc Config](http://usejsdoc.org/about-configuring-jsdoc.html) (experimental)                                                         |


### PR DESCRIPTION
This replaces the use of example filename `exclude.js` in the README.md for the `--include` parameter with `include.js`, with the intention of improving readability.